### PR TITLE
Implement the builder pattern

### DIFF
--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1,7 +1,7 @@
-use crate::Gym;
+use crate::gym::Gym;
 use candle_core::{Tensor, Var};
 mod dqn;
-pub use dqn::DQNActor;
+pub use dqn::*;
 
 pub trait Actor {
     type Error;

--- a/src/actors/dqn.rs
+++ b/src/actors/dqn.rs
@@ -297,7 +297,8 @@ mod tests {
 
     use super::*;
     use crate::gym::common_gyms::CartPole;
-    use crate::{gym::Gym, models::MLP};
+    use crate::gym::Gym;
+    use crate::models::MLPBuilder;
 
     // Test the DQN actor by training it on the CartPole environment.
     #[test]
@@ -307,18 +308,17 @@ mod tests {
         let var_map = VarMap::new();
         let mut vb =
             VarBuilder::from_varmap(&var_map, candle_core::DType::F32, &candle_core::Device::Cpu);
-        let mlp = MLP::new(
+
+        let mlp = MLPBuilder::new(
             observation_space
                 .sample(&candle_core::Device::Cpu)
                 .shape()
                 .elem_count(),
-            vec![32, 32, 32],
             2,
-            candle_nn::Activation::Gelu,
-            None,
-            &mut vb,
         )
+        .build(&mut vb)
         .expect("Failed to create MLP");
+
         let optimizer =
             AdamW::new(var_map.all_vars(), ParamsAdamW::default()).expect("Failed to create AdamW");
 

--- a/src/actors/dqn.rs
+++ b/src/actors/dqn.rs
@@ -4,7 +4,11 @@ use candle_core::{safetensors::save, Error, Tensor, Var};
 use candle_nn::Optimizer;
 use rand::Rng;
 
-use crate::{Discrete, Experience, ExperienceReplay, Gym, Space};
+use crate::{
+    experience_replay::{Experience, ExperienceReplay},
+    gym::Gym,
+    spaces::{Discrete, Space},
+};
 
 use super::Actor;
 
@@ -27,11 +31,105 @@ where
     epochs: usize,
 }
 
-impl<O> DQNActor<O>
+pub struct DQNActorBuilder<O>
+where
+    O: Optimizer,
+{
+    // Everything other than the spaces are optional.
+    q_network: Box<dyn candle_core::Module>,
+    optimizer: O,
+    epsilon_start: Option<f32>,
+    epsilon_decay: Option<f32>,
+    action_space: Discrete,
+    observation_space: Box<dyn Space>,
+    batch_size: Option<usize>,
+    gamma: Option<f32>,
+    replay_capacity: Option<usize>,
+    epochs: Option<usize>,
+}
+
+impl<O> DQNActorBuilder<O>
 where
     O: Optimizer,
 {
     pub fn new(
+        action_space: Discrete,
+        observation_space: Box<dyn Space>,
+        q_network: Box<dyn candle_core::Module>,
+        optimizer: O,
+    ) -> Self {
+        Self {
+            q_network: q_network,
+            optimizer: optimizer,
+            epsilon_start: None,
+            epsilon_decay: None,
+            action_space,
+            observation_space,
+            batch_size: None,
+            gamma: None,
+            replay_capacity: None,
+            epochs: None,
+        }
+    }
+
+    pub fn epsilon_start(mut self, epsilon_start: f32) -> Self {
+        self.epsilon_start = Some(epsilon_start);
+        self
+    }
+
+    pub fn epsilon_decay(mut self, epsilon_decay: f32) -> Self {
+        self.epsilon_decay = Some(epsilon_decay);
+        self
+    }
+
+    pub fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
+    pub fn gamma(mut self, gamma: f32) -> Self {
+        self.gamma = Some(gamma);
+        self
+    }
+
+    pub fn replay_capacity(mut self, replay_capacity: usize) -> Self {
+        self.replay_capacity = Some(replay_capacity);
+        self
+    }
+
+    pub fn epochs(mut self, epochs: usize) -> Self {
+        self.epochs = Some(epochs);
+        self
+    }
+
+    pub fn build(self) -> DQNActor<O> {
+        let epsilon_start = self.epsilon_start.unwrap_or(0.9);
+        let epsilon_decay = self.epsilon_decay.unwrap_or(0.99);
+        let batch_size = self.batch_size.unwrap_or(32);
+        let gamma = self.gamma.unwrap_or(0.99);
+        let replay_capacity = self.replay_capacity.unwrap_or(10000);
+        let epochs = self.epochs.unwrap_or(10);
+
+        DQNActor::new(
+            self.q_network,
+            self.optimizer,
+            epsilon_start,
+            epsilon_decay,
+            self.action_space,
+            self.observation_space,
+            batch_size,
+            gamma,
+            replay_capacity,
+            epochs,
+        )
+    }
+}
+
+impl<O> DQNActor<O>
+where
+    O: Optimizer,
+{
+    fn new(
         q_network: Box<dyn candle_core::Module>,
         optimizer: O,
         epsilon_start: f32,
@@ -198,8 +296,8 @@ mod tests {
     use candle_nn::{AdamW, ParamsAdamW, VarBuilder, VarMap};
 
     use super::*;
-    use crate::gym::CartPole;
-    use crate::{Gym, MLP};
+    use crate::gym::common_gyms::CartPole;
+    use crate::{gym::Gym, models::MLP};
 
     // Test the DQN actor by training it on the CartPole environment.
     #[test]
@@ -221,20 +319,17 @@ mod tests {
             &mut vb,
         )
         .expect("Failed to create MLP");
+        let optimizer =
+            AdamW::new(var_map.all_vars(), ParamsAdamW::default()).expect("Failed to create AdamW");
 
-        let mut actor = DQNActor::new(
-            Box::new(mlp),
-            AdamW::new(var_map.all_vars(), ParamsAdamW::default()).expect("Failed to create AdamW"),
-            0.9,
-            0.99,
-            Discrete::new(2, 0), // had to hardcode this puppy in sadly.
+        let mut actor = DQNActorBuilder::new(
+            Discrete::new(2, 0), // had to hardcode this :(
             observation_space,
-            128,
-            0.99,
-            1000,
-            1,
-        );
+            Box::new(mlp),
+            optimizer,
+        )
+        .build();
 
-        actor.learn(&mut env, 600).expect("Failed to learn");
+        actor.learn(&mut env, 20).expect("Failed to learn");
     }
 }

--- a/src/experience_replay.rs
+++ b/src/experience_replay.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use candle_core::{Device, Error, Tensor};
+use candle_core::{Error, Tensor};
 use rand::Rng;
 
 // Not sure if this needs to be more flexible or not.

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -1,7 +1,6 @@
+use crate::spaces::Space;
 use candle_core::Tensor;
-mod common_gyms;
-use crate::Space;
-pub use common_gyms::*;
+pub mod common_gyms;
 
 pub trait Gym {
     type Error;

--- a/src/gym/common_gyms.rs
+++ b/src/gym/common_gyms.rs
@@ -1,4 +1,4 @@
-use crate::{spaces, Gym, Space};
+use crate::{gym::Gym, spaces, spaces::Space};
 use candle_core::{Device, Tensor};
 use log;
 
@@ -6,7 +6,6 @@ use log;
 /// Converted from the OpenAI Gym CartPole environment.
 pub struct CartPole {
     pub(crate) gravity: f32,
-    pub(crate) masscart: f32,
     pub(crate) masspole: f32,
     pub(crate) total_mass: f32,
     pub(crate) length: f32,
@@ -53,7 +52,6 @@ impl CartPole {
 
         Self {
             gravity,
-            masscart,
             masspole,
             total_mass,
             length,
@@ -154,11 +152,11 @@ impl Gym for CartPole {
         }
     }
 
-    fn observation_space(&self) -> Box<dyn crate::Space> {
+    fn observation_space(&self) -> Box<dyn crate::spaces::Space> {
         Box::new(self.observation_space.clone())
     }
 
-    fn action_space(&self) -> Box<dyn crate::Space> {
+    fn action_space(&self) -> Box<dyn crate::spaces::Space> {
         Box::new(self.action_space.clone())
     }
 }
@@ -166,7 +164,7 @@ impl Gym for CartPole {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Gym;
+    use crate::gym::Gym;
 
     #[test]
     fn test_cartpole() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,5 @@
-mod gym;
-pub use gym::Gym;
-mod spaces;
-pub use spaces::*;
-mod actors;
-pub use actors::*;
-mod experience_replay;
-pub use experience_replay::*;
-mod models;
-pub use models::*;
+pub mod actors;
+pub mod experience_replay;
+pub mod gym;
+pub mod models;
+pub mod spaces;

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,8 +9,58 @@ pub struct MLP {
     output_activation: Option<candle_nn::Activation>,
 }
 
+pub struct MLPBuilder {
+    pub input_size: usize,
+    pub output_size: usize,
+    pub hidden_layer_sizes: Option<Vec<usize>>,
+    pub activation: Option<candle_nn::Activation>,
+    pub output_activation: Option<candle_nn::Activation>,
+}
+
+impl MLPBuilder {
+    pub fn new(input_size: usize, output_size: usize) -> Self {
+        Self {
+            input_size,
+            output_size,
+            hidden_layer_sizes: None,
+            activation: None,
+            output_activation: None,
+        }
+    }
+
+    pub fn hidden_layer_sizes(mut self, hidden_layer_sizes: Vec<usize>) -> Self {
+        self.hidden_layer_sizes = Some(hidden_layer_sizes);
+        self
+    }
+
+    pub fn activation(mut self, activation: candle_nn::Activation) -> Self {
+        self.activation = Some(activation);
+        self
+    }
+
+    pub fn output_activation(mut self, output_activation: candle_nn::Activation) -> Self {
+        self.output_activation = Some(output_activation);
+        self
+    }
+
+    pub fn build(self, vb: &mut VarBuilder) -> Result<MLP, Error> {
+        let hidden_layer_sizes = self.hidden_layer_sizes.unwrap_or(vec![32, 32, 32]);
+        let activation = self.activation.unwrap_or(candle_nn::Activation::Relu);
+        // output layer activation is optional and defaults to None
+
+        MLP::new(
+            self.input_size,
+            hidden_layer_sizes,
+            self.output_size,
+            activation,
+            self.output_activation,
+            vb,
+        )
+    }
+}
+
 impl MLP {
-    pub fn new(
+    fn new(
         input_size: usize,
         hidden_layer_sizes: Vec<usize>,
         output_size: usize,


### PR DESCRIPTION
This implements the builder pattern for MLP and DQN. This should be the go-to for big structs with optional values. That way, a common value can be used if the developer doesn't know what some hyper-parameter is.