### PR TITLE
Generalize MLP Probabilistic Actor

### DIFF
--- a/examples/ppo_bench.rs
+++ b/examples/ppo_bench.rs
@@ -6,7 +6,7 @@ use modurl::tensor_operations::tanh;
 use modurl::{
     actors::{Actor, ppo::PPOActor},
     distributions::CategoricalDistribution,
-    models::{MLP, probabilistic_model::MLPProbabilisticActor},
+    models::{MLP, probabilistic_model::ProbabilisticActorModel},
 };
 use modurl_gym::classic_control::cartpole::CartPoleV1;
 
@@ -75,7 +75,7 @@ fn ppo_cartpole() {
     let mut actor = PPOActor::builder()
         .action_space(action_space)
         .actor_network(Box::new(
-            MLPProbabilisticActor::<CategoricalDistribution>::new(actor_network),
+            ProbabilisticActorModel::<CategoricalDistribution>::new(Box::new(actor_network)),
         ))
         .critic_network(Box::new(critic_network))
         .critic_optimizer(critic_optimizer)

--- a/examples/ppo_cartpole_with_graphs.rs
+++ b/examples/ppo_cartpole_with_graphs.rs
@@ -7,7 +7,7 @@ use modurl::tensor_operations::tanh;
 use modurl::{
     actors::{Actor, ppo::PPOActor},
     distributions::CategoricalDistribution,
-    models::{MLP, probabilistic_model::MLPProbabilisticActor},
+    models::{MLP, probabilistic_model::ProbabilisticActorModel},
 };
 use modurl_gym::classic_control::cartpole::CartPoleV1;
 use textplots::{Chart, Plot};
@@ -257,7 +257,7 @@ fn ppo_cartpole() {
     let mut actor = PPOActor::builder()
         .action_space(action_space)
         .actor_network(Box::new(
-            MLPProbabilisticActor::<CategoricalDistribution>::new(actor_network),
+            ProbabilisticActorModel::<CategoricalDistribution>::new(Box::new(actor_network)),
         ))
         .critic_network(Box::new(critic_network))
         .critic_optimizer(critic_optimizer)

--- a/examples/rendered_lunar_lander_ppo.rs
+++ b/examples/rendered_lunar_lander_ppo.rs
@@ -8,7 +8,7 @@ use modurl::{
     actors::{Actor, ppo::PPOActor},
     distributions::CategoricalDistribution,
     gym::Gym,
-    models::{MLP, probabilistic_model::MLPProbabilisticActor},
+    models::{MLP, probabilistic_model::ProbabilisticActorModel},
 };
 use modurl_gym::box_2d::lunar_lander::LunarLanderV3;
 
@@ -119,7 +119,7 @@ fn main() {
     let mut actor = PPOActor::builder()
         .action_space(action_space)
         .actor_network(Box::new(
-            MLPProbabilisticActor::<CategoricalDistribution>::new(actor_network),
+            ProbabilisticActorModel::<CategoricalDistribution>::new(Box::new(actor_network)),
         ))
         .critic_network(Box::new(critic_network))
         .critic_optimizer(critic_optimizer)

--- a/src/models/probabilistic_model.rs
+++ b/src/models/probabilistic_model.rs
@@ -39,7 +39,7 @@ pub enum ProbabilisticActorModelError<DE>
 where
     DE: std::fmt::Debug,
 {
-    MLPError(candle_core::Error),
+    ModuleError(candle_core::Error),
     DistError(DE),
 }
 
@@ -48,7 +48,7 @@ where
     DE: std::fmt::Debug,
 {
     fn from(error: candle_core::Error) -> Self {
-        ProbabilisticActorModelError::MLPError(error)
+        ProbabilisticActorModelError::ModuleError(error)
     }
 }
 

--- a/tests/test_cartpole.rs
+++ b/tests/test_cartpole.rs
@@ -9,7 +9,7 @@ use modurl::{
     actors::{Actor, ppo::PPOActor},
     distributions::CategoricalDistribution,
     gym::{Gym, StepInfo},
-    models::{MLP, probabilistic_model::MLPProbabilisticActor},
+    models::{MLP, probabilistic_model::ProbabilisticActorModel},
     spaces::Discrete,
 };
 use modurl_gym::classic_control::cartpole::CartPoleV1;
@@ -158,7 +158,7 @@ fn ppo_cartpole() {
     let mut actor = PPOActor::builder()
         .action_space(action_space)
         .actor_network(Box::new(
-            MLPProbabilisticActor::<CategoricalDistribution>::new(actor_network),
+            ProbabilisticActorModel::<CategoricalDistribution>::new(Box::new(actor_network)),
         ))
         .critic_network(Box::new(critic_network))
         .critic_optimizer(critic_optimizer)


### PR DESCRIPTION
Now it's called ```ProbabilisticActorModel``` and takes any ```Box<dyn Module>``` that way we aren't needlessly restrictive.