### PR TITLE
Add Info Generic interface to Gym

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block"
@@ -116,14 +116,14 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5150004def1b5eb8db8c80fac41437dabda563ccc49f8a71dac4ffd132615ba5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -172,7 +172,7 @@ dependencies = [
  "num_cpus",
  "objc2-foundation",
  "objc2-metal",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
  "rayon",
  "safetensors 0.8.0",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -259,17 +259,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "colored"
@@ -338,15 +327,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -422,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ba848ae5c6f3cb36e71eab5f268763e3fabcabe3f7bc683e16f7fa3d46281e"
+checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
 dependencies = [
  "half",
  "libloading 0.8.9",
@@ -562,11 +542,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -677,7 +657,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
 ]
 
@@ -732,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -763,9 +743,9 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -774,15 +754,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -803,9 +783,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -815,7 +795,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1088,7 +1067,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1107,7 +1085,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
  "zerocopy",
 ]
@@ -1188,13 +1166,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1242,7 +1219,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall",
@@ -1316,7 +1293,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -1376,14 +1353,13 @@ dependencies = [
 [[package]]
 name = "modurl_gym"
 version = "0.1.0"
-source = "git+https://github.com/ModuRL/ModuRL_Gym#5dafbcd52125f490a467bf255aa9201858d42661"
+source = "git+https://github.com/ModuRL/ModuRL_Gym#70dbc6c88b1031ddb7fc20b25efc6666f745c861"
 dependencies = [
  "bon",
  "box2d-rs",
  "candle-core",
  "minifb",
  "modurl",
- "rand 0.10.2",
 ]
 
 [[package]]
@@ -1534,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -1547,7 +1523,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -1564,7 +1540,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1577,7 +1553,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -1597,7 +1573,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1635,12 +1611,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1742,23 +1712,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1768,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1781,19 +1740,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand",
 ]
 
 [[package]]
@@ -1802,7 +1755,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1854,14 +1807,14 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1871,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1888,9 +1841,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -1901,7 +1854,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2037,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2100,9 +2053,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2126,7 +2079,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -2199,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2225,7 +2178,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.4",
+ "rand",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2335,7 +2288,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
 dependencies = [
- "cudarc 0.17.3",
+ "cudarc 0.17.8",
  "half",
  "serde",
  "thiserror 1.0.69",
@@ -2413,18 +2366,18 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2437,21 +2390,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2459,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2472,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -2554,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2701,9 +2652,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "x11-dl"
@@ -2830,6 +2781,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/docs/src/custom-gym-environment.md
+++ b/docs/src/custom-gym-environment.md
@@ -34,9 +34,12 @@ impl Gym for CounterEnv {
     type Error = candle_core::Error;
     type SpaceError = candle_core::Error;
 
-    fn reset(&mut self) -> Result<Tensor, Self::Error> {
+    fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
         self.state = 0;
-        self.observation()
+        Ok(ResetInfo {
+            state: self.observation()?,
+            info: (),
+        })
     }
 
     fn step(&mut self, action: Tensor) -> Result<StepInfo, Self::Error> {
@@ -52,6 +55,7 @@ impl Gym for CounterEnv {
             reward: 1.0,
             done,
             truncated: false,
+            info: (),
         })
     }
 
@@ -70,8 +74,11 @@ impl Gym for CounterEnv {
 }
 ```
 
-`reset` returns the initial observation. `step` consumes one action and returns
-the observation that follows it, its reward, and the episode flags.
+`reset` returns the initial observation and `step` consumes one action and
+returns the observation that follows it, its reward, and the episode flags.
+The default `Gym` information type is `()`, so ordinary environments use
+`ResetInfo` and `StepInfo` without an explicit type parameter. Environments
+with additional typed metadata can instead implement `Gym<MyInfo>`.
 
 In `src/main.rs`, declare the module and bring the environment into scope:
 

--- a/examples/rendered_lunar_lander_ppo.rs
+++ b/examples/rendered_lunar_lander_ppo.rs
@@ -32,7 +32,7 @@ impl Gym for DebugLunarLander {
         self.env.observation_space()
     }
 
-    fn reset(&mut self) -> Result<Tensor, Self::Error> {
+    fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
         self.episodes_since_print += 1;
         if self.episodes_since_print >= 10 {
             println!(

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -23,7 +23,7 @@ pub(crate) mod test_support {
     use candle_nn::Optimizer;
 
     use crate::{
-        gym::{Gym, StepInfo},
+        gym::{Gym, ResetInfo, StepInfo},
         spaces::{BoxSpace, Discrete, Space},
     };
 
@@ -47,11 +47,15 @@ pub(crate) mod test_support {
                 reward: 1.0,
                 done: false,
                 truncated: false,
+                info: (),
             })
         }
 
-        fn reset(&mut self) -> Result<Tensor, Self::Error> {
-            Tensor::zeros(&[4], DType::F32, &self.device)
+        fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
+            Ok(ResetInfo {
+                state: Tensor::zeros(&[4], DType::F32, &self.device)?,
+                info: (),
+            })
         }
 
         fn observation_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {

--- a/src/agents/ppo.rs
+++ b/src/agents/ppo.rs
@@ -981,7 +981,7 @@ mod tests {
     use super::*;
     use crate::{
         distributions::CategoricalDistribution,
-        gym::{Gym, StepInfo, VectorizedGym, VectorizedGymWrapper},
+        gym::{Gym, ResetInfo, StepInfo, VectorizedGym, VectorizedGymWrapper},
         models::{MLP, probabilistic_model::ProbabilisticPolicyModel},
         spaces::Discrete,
         tensor_operations::tanh,
@@ -1016,12 +1016,16 @@ mod tests {
                 reward: self.step_count as f32,
                 done: next_done,
                 truncated: false,
+                info: (),
             })
         }
 
-        fn reset(&mut self) -> Result<Tensor, Self::Error> {
+        fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
             self.step_count = 0;
-            Tensor::rand(0.0f32, 1.0, &[4], &self.device)
+            Ok(ResetInfo {
+                state: Tensor::rand(0.0f32, 1.0, &[4], &self.device)?,
+                info: (),
+            })
         }
 
         fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {

--- a/src/agents/q_learning.rs
+++ b/src/agents/q_learning.rs
@@ -560,7 +560,7 @@ mod tests {
     };
     use crate::{
         agents::test_support::{CountingOptimizer, FixedEnv},
-        gym::{Gym, StepInfo, VectorizedGym, VectorizedGymError, VectorizedGymWrapper},
+        gym::{Gym, ResetInfo, StepInfo, VectorizedGym, VectorizedGymError, VectorizedGymWrapper},
         models::MLP,
         parameter_schedule::LinearSchedule,
         spaces::{BoxSpace, Discrete},
@@ -691,12 +691,16 @@ mod tests {
                 reward: 1.0,
                 done: self.steps == 2,
                 truncated: false,
+                info: (),
             })
         }
 
-        fn reset(&mut self) -> Result<Tensor, Self::Error> {
+        fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
             self.steps = 0;
-            Tensor::zeros(&[4], DType::F32, &self.device)
+            Ok(ResetInfo {
+                state: Tensor::zeros(&[4], DType::F32, &self.device)?,
+                info: (),
+            })
         }
 
         fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -1,14 +1,19 @@
 use crate::spaces::Space;
 use candle_core::Tensor;
 
-pub trait Gym {
+/// A single reinforcement-learning environment.
+///
+/// `I` is typed environment metadata returned by resets and transitions. It
+/// defaults to `()`, so environments without extra metadata can simply write
+/// `impl Gym for MyEnvironment`.
+pub trait Gym<I = ()> {
     type Error;
     type SpaceError;
 
     /// Returns the next state, reward, and done flag.
-    fn step(&mut self, action: Tensor) -> Result<StepInfo, Self::Error>;
-    /// Resets the environment to its initial state. Returns the initial state.
-    fn reset(&mut self) -> Result<Tensor, Self::Error>;
+    fn step(&mut self, action: Tensor) -> Result<StepInfo<I>, Self::Error>;
+    /// Resets the environment to its initial state.
+    fn reset(&mut self) -> Result<ResetInfo<I>, Self::Error>;
     /// Returns the observation space.
     fn observation_space(&self) -> Box<dyn Space<Error = Self::SpaceError>>;
     /// Returns the action space.
@@ -51,11 +56,20 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct StepInfo {
+/// The initial observation and environment-specific metadata from a reset.
+pub struct ResetInfo<I = ()> {
+    pub state: Tensor,
+    pub info: I,
+}
+
+#[derive(Debug, Clone)]
+/// The result of one environment transition.
+pub struct StepInfo<I = ()> {
     pub state: Tensor,
     pub reward: f32,
     pub done: bool,
     pub truncated: bool,
+    pub info: I,
 }
 
 #[derive(Debug, Clone)]
@@ -85,16 +99,24 @@ impl VectorizedStepInfo {
     }
 }
 
-pub struct VectorizedGymWrapper<G: Gym> {
+pub struct VectorizedGymWrapper<G, I = ()>
+where
+    G: Gym<I>,
+{
     envs: Vec<G>,
     to_reset: Vec<bool>,
+    _info: std::marker::PhantomData<fn() -> I>,
 }
 
-impl<G: Gym> VectorizedGymWrapper<G> {
+impl<G, I> VectorizedGymWrapper<G, I>
+where
+    G: Gym<I>,
+{
     pub fn new(envs: Vec<G>) -> Self {
         Self {
             to_reset: vec![true; envs.len()],
             envs,
+            _info: std::marker::PhantomData,
         }
     }
 
@@ -107,9 +129,9 @@ impl<G: Gym> VectorizedGymWrapper<G> {
     }
 }
 
-impl<G> VectorizedGym for VectorizedGymWrapper<G>
+impl<G, I> VectorizedGym for VectorizedGymWrapper<G, I>
 where
-    G: Gym,
+    G: Gym<I>,
     G::Error: std::fmt::Debug,
 {
     type Error = VectorizedGymError<G::Error>;
@@ -137,7 +159,7 @@ where
                 None
             };
             if step_info.done || step_info.truncated {
-                step_info.state = env.reset().map_err(VectorizedGymError::Single)?;
+                step_info.state = env.reset().map_err(VectorizedGymError::Single)?.state;
             }
 
             states.push(step_info.state);
@@ -173,8 +195,8 @@ where
 
         for i in 0..batch_size {
             let env = &mut self.envs[i];
-            let state = env.reset().map_err(VectorizedGymError::Single)?;
-            states.push(state);
+            let reset = env.reset().map_err(VectorizedGymError::Single)?;
+            states.push(reset.state);
             self.to_reset[i] = false;
         }
 
@@ -187,18 +209,18 @@ where
     }
 }
 
-impl<G> From<G> for VectorizedGymWrapper<G>
+impl<G, I> From<G> for VectorizedGymWrapper<G, I>
 where
-    G: Gym + Clone,
+    G: Gym<I> + Clone,
 {
     fn from(env: G) -> Self {
         VectorizedGymWrapper::new(vec![env])
     }
 }
 
-impl<G> From<Vec<G>> for VectorizedGymWrapper<G>
+impl<G, I> From<Vec<G>> for VectorizedGymWrapper<G, I>
 where
-    G: Gym,
+    G: Gym<I>,
 {
     fn from(envs: Vec<G>) -> Self {
         VectorizedGymWrapper::new(envs)
@@ -209,29 +231,31 @@ where
 use std::{fmt::Debug, sync::mpsc, thread};
 
 #[cfg(feature = "multithreading")]
-pub struct MultithreadedVectorizedGymWrapper<G, O, A, SE>
+pub struct MultithreadedVectorizedGymWrapper<G, O, A, SE, I = ()>
 where
-    G: Gym + 'static,
+    G: Gym<I> + 'static,
     G::Error: Send + Sync + std::fmt::Debug,
     SE: Debug,
     A: Space<Error = SE> + Clone + 'static,
     O: Space<Error = SE> + Clone + 'static,
+    I: Send + 'static,
 {
-    envs: Vec<GymHandle<G::Error>>,
+    envs: Vec<GymHandle<G::Error, I>>,
     to_reset: Vec<bool>,
     obs_space: O,
     action_space: A,
-    _phantom: std::marker::PhantomData<SE>,
+    _phantom: std::marker::PhantomData<(SE, fn() -> I)>,
 }
 
 #[cfg(feature = "multithreading")]
-impl<G, O, A, SE> MultithreadedVectorizedGymWrapper<G, O, A, SE>
+impl<G, O, A, SE, I> MultithreadedVectorizedGymWrapper<G, O, A, SE, I>
 where
-    G: Gym + 'static,
+    G: Gym<I> + 'static,
     G::Error: Send + Sync + std::fmt::Debug,
     SE: Debug,
     A: Space<Error = SE> + Clone + 'static,
     O: Space<Error = SE> + Clone + 'static,
+    I: Send + 'static,
 {
     pub fn new<F>(env_constructors: Vec<F>, obs_space: O, action_space: A) -> Self
     where
@@ -242,7 +266,7 @@ where
             "Must provide at least one environment constructor"
         );
 
-        let envs: Vec<GymHandle<<G as Gym>::Error>> = env_constructors
+        let envs: Vec<GymHandle<<G as Gym<I>>::Error, I>> = env_constructors
             .into_iter()
             .map(|constructor| start_gym_thread(constructor))
             .collect();
@@ -258,13 +282,14 @@ where
 }
 
 #[cfg(feature = "multithreading")]
-impl<G, O, A, SE> VectorizedGym for MultithreadedVectorizedGymWrapper<G, O, A, SE>
+impl<G, O, A, SE, I> VectorizedGym for MultithreadedVectorizedGymWrapper<G, O, A, SE, I>
 where
-    G: Gym + 'static,
+    G: Gym<I> + 'static,
     G::Error: Send + Sync + std::fmt::Debug,
     SE: Debug,
     A: Space<Error = SE> + Clone + 'static,
     O: Space<Error = SE> + Clone + 'static,
+    I: Send + 'static,
 {
     type Error = VectorizedGymError<G::Error>;
     type SpaceError = SE;
@@ -324,7 +349,7 @@ where
     fn reset(&mut self) -> Result<Tensor, Self::Error> {
         let batch_size = self.envs.len();
 
-        let states: Vec<std::sync::mpsc::Receiver<Result<StepInfo, <G as Gym>::Error>>> =
+        let states: Vec<std::sync::mpsc::Receiver<Result<ResetInfo<I>, <G as Gym<I>>::Error>>> =
             self.envs.iter().map(|env| env.reset()).collect();
         let states: Vec<Result<Tensor, VectorizedGymError<G::Error>>> = states
             .into_iter()
@@ -359,40 +384,40 @@ where
 }
 
 #[cfg(feature = "multithreading")]
-enum GymCmd<E>
+enum GymCmd<E, I>
 where
     E: Send + Sync,
 {
-    Step(Tensor, mpsc::Sender<Result<ThreadStepInfo, E>>),
-    Reset(mpsc::Sender<Result<StepInfo, E>>),
+    Step(Tensor, mpsc::Sender<Result<ThreadStepInfo<I>, E>>),
+    Reset(mpsc::Sender<Result<ResetInfo<I>, E>>),
 }
 
 #[cfg(feature = "multithreading")]
-struct ThreadStepInfo {
-    step_info: StepInfo,
+struct ThreadStepInfo<I> {
+    step_info: StepInfo<I>,
     terminal_state: Option<Tensor>,
 }
 
 #[cfg(feature = "multithreading")]
-struct GymHandle<E>
+struct GymHandle<E, I>
 where
     E: Send + Sync,
 {
-    tx: mpsc::Sender<GymCmd<E>>,
+    tx: mpsc::Sender<GymCmd<E, I>>,
 }
 
 #[cfg(feature = "multithreading")]
-impl<E> GymHandle<E>
+impl<E, I> GymHandle<E, I>
 where
     E: Send + Sync,
 {
-    fn step(&self, action: Tensor) -> std::sync::mpsc::Receiver<Result<ThreadStepInfo, E>> {
+    fn step(&self, action: Tensor) -> std::sync::mpsc::Receiver<Result<ThreadStepInfo<I>, E>> {
         let (resp_tx, resp_rx) = mpsc::channel();
         self.tx.send(GymCmd::Step(action, resp_tx)).unwrap();
         return resp_rx;
     }
 
-    fn reset(&self) -> std::sync::mpsc::Receiver<Result<StepInfo, E>> {
+    fn reset(&self) -> std::sync::mpsc::Receiver<Result<ResetInfo<I>, E>> {
         let (resp_tx, resp_rx) = mpsc::channel();
         self.tx.send(GymCmd::Reset(resp_tx)).unwrap();
         return resp_rx;
@@ -402,13 +427,14 @@ where
 #[cfg(feature = "multithreading")]
 /// Spawns a persistent thread that constructs and owns the gym.
 /// The closure is executed inside that thread to build the gym.
-fn start_gym_thread<G, F>(make_gym: F) -> GymHandle<G::Error>
+fn start_gym_thread<G, F, I>(make_gym: F) -> GymHandle<G::Error, I>
 where
     F: FnOnce() -> G + Send + 'static,
-    G: Gym + 'static,
+    G: Gym<I> + 'static,
     G::Error: Send + Sync + 'static,
+    I: Send + 'static,
 {
-    let (tx, rx) = mpsc::channel::<GymCmd<G::Error>>();
+    let (tx, rx) = mpsc::channel::<GymCmd<G::Error, I>>();
 
     thread::spawn(move || {
         let mut gym = make_gym(); // constructed *inside* the thread
@@ -422,8 +448,8 @@ where
                     {
                         terminal_state = Some(info.state.clone());
                         match gym.reset() {
-                            Ok(state) => {
-                                info.state = state;
+                            Ok(reset) => {
+                                info.state = reset.state;
                             }
                             Err(err) => {
                                 resp_tx.send(Err(err)).expect(
@@ -444,23 +470,9 @@ where
                 }
                 GymCmd::Reset(resp_tx) => {
                     let reset_info = gym.reset();
-                    if let Some(state) = reset_info.as_ref().ok() {
-                        resp_tx
-                            .send(Ok(StepInfo {
-                                state: state.clone(),
-                                reward: 0.0,
-                                done: false,
-                                truncated: false,
-                            }))
-                            .expect(
-                                "Failed to send reset response, this was probably caused by a panic in the gym thread",
-                            );
-                    } else {
-                        resp_tx.send(Err(reset_info.err().unwrap())).expect(
-                            "Failed to send reset response, this was probably caused by a panic in the gym thread",
-                        );
-                        continue;
-                    }
+                    resp_tx.send(reset_info).expect(
+                        "Failed to send reset response, this was probably caused by a panic in the gym thread",
+                    );
                 }
             }
         }
@@ -472,6 +484,49 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct TestInfo {
+        value: usize,
+    }
+
+    struct InfoEnv;
+
+    impl Gym<TestInfo> for InfoEnv {
+        type Error = candle_core::Error;
+        type SpaceError = candle_core::Error;
+
+        fn step(&mut self, _action: Tensor) -> Result<StepInfo<TestInfo>, Self::Error> {
+            Ok(StepInfo {
+                state: Tensor::zeros(1, candle_core::DType::F32, &candle_core::Device::Cpu)?,
+                reward: 0.0,
+                done: false,
+                truncated: false,
+                info: TestInfo { value: 2 },
+            })
+        }
+
+        fn reset(&mut self) -> Result<ResetInfo<TestInfo>, Self::Error> {
+            Ok(ResetInfo {
+                state: Tensor::zeros(1, candle_core::DType::F32, &candle_core::Device::Cpu)?,
+                info: TestInfo { value: 1 },
+            })
+        }
+
+        fn observation_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {
+            Box::new(crate::spaces::BoxSpace::new_with_universal_bounds(
+                vec![1],
+                -1.0,
+                1.0,
+                &candle_core::Device::Cpu,
+            ))
+        }
+
+        fn action_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {
+            Box::new(crate::spaces::Discrete::new(2))
+        }
+    }
+
     struct DummyEnv {
         step_count: usize,
         id: usize,
@@ -500,15 +555,17 @@ mod tests {
                 reward: 1.0,
                 done,
                 truncated: false,
+                info: (),
             })
         }
 
-        fn reset(&mut self) -> Result<Tensor, Self::Error> {
+        fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
             self.step_count = 0;
-            Ok(
-                Tensor::from_vec(vec![self.id as f32, 0.0], &[2], &candle_core::Device::Cpu)
+            Ok(ResetInfo {
+                state: Tensor::from_vec(vec![self.id as f32, 0.0], &[2], &candle_core::Device::Cpu)
                     .unwrap(),
-            )
+                info: (),
+            })
         }
 
         fn observation_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {
@@ -576,6 +633,16 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn vectorized_wrapper_infers_and_erases_non_unit_info() {
+        let mut vec_env = VectorizedGymWrapper::from(vec![InfoEnv]);
+        assert_eq!(vec_env.reset().unwrap().dims(), &[1, 1]);
+
+        let actions =
+            Tensor::zeros((1, 1), candle_core::DType::U32, &candle_core::Device::Cpu).unwrap();
+        assert_eq!(vec_env.step(actions).unwrap().states.dims(), &[1, 1]);
     }
 
     #[cfg(feature = "multithreading")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod parameter_schedule;
 pub mod prelude;
 pub mod spaces;
 pub mod tensor_operations;
+pub mod wrappers;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -36,3 +36,7 @@ pub use crate::parameter_schedule::{
 };
 pub use crate::spaces::{BoxSpace, Discrete, Space};
 pub use crate::tensor_operations::tanh;
+pub use crate::wrappers::{
+    ClipRewardGym, ClipRewardGymError, FrameStackGym, FrameStackGymError, MaxAndSkipGym,
+    MaxAndSkipGymError, TimeLimitGym,
+};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,7 +22,9 @@ pub use crate::distributions::{
 };
 #[cfg(feature = "multithreading")]
 pub use crate::gym::MultithreadedVectorizedGymWrapper;
-pub use crate::gym::{Gym, StepInfo, VectorizedGym, VectorizedGymError, VectorizedGymWrapper};
+pub use crate::gym::{
+    Gym, ResetInfo, StepInfo, VectorizedGym, VectorizedGymError, VectorizedGymWrapper,
+};
 pub use crate::models::{
     DefaultMLPInitializer, MLP, MLPArchitecture, MLPInitializedLayers, MLPInitializer,
     OrthogonalMLPInitializer, probabilistic_model::ProbabilisticPolicy,

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -83,7 +83,7 @@ impl Space for BoxSpace {
         let low = self.low.flatten_all().expect("Failed to flatten tensor.");
         let high = self.high.flatten_all().expect("Failed to flatten tensor.");
         // we might be losing some precision here, but it's fine for now.
-        let rng_bases = Tensor::rand(0.0, 1.0, low.shape(), device)?;
+        let rng_bases = Tensor::rand(0.0_f32, 1.0_f32, low.shape(), device)?;
         for i in 0..low.shape().dim(0).expect("Failed to get dim.") {
             let mut low = low
                 .get(i)
@@ -195,4 +195,18 @@ fn finitize(value: f32) -> f32 {
         return f32::MIN / 2.0;
     }
     value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn box_space_samples_are_f32() {
+        let space = BoxSpace::new_with_universal_bounds(vec![3], -1.0, 1.0, &Device::Cpu);
+        let sample = space.sample(&Device::Cpu).unwrap();
+
+        assert_eq!(sample.dtype(), candle_core::DType::F32);
+        assert!(space.contains(&sample));
+    }
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,0 +1,97 @@
+//! Environment-independent wrappers for [`crate::gym::Gym`].
+//!
+//! The modules follow Gymnasium's conventional categories: observation
+//! transformations, reward transformations, and episode-control wrappers.
+
+pub mod observation;
+pub mod reward;
+pub mod time_limit;
+
+pub use observation::{FrameStackGym, FrameStackGymError, MaxAndSkipGym, MaxAndSkipGymError};
+pub use reward::{ClipRewardGym, ClipRewardGymError};
+pub use time_limit::TimeLimitGym;
+
+#[cfg(test)]
+mod test_support {
+    use std::collections::VecDeque;
+
+    use candle_core::{Device, Tensor};
+
+    use crate::{
+        gym::{Gym, ResetInfo, StepInfo},
+        spaces::{BoxSpace, Discrete, Space},
+    };
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(super) struct TestInfo {
+        pub(super) sequence: u32,
+    }
+
+    pub(super) struct TestGym {
+        steps: VecDeque<StepInfo<TestInfo>>,
+        device: Device,
+        reset_count: u32,
+    }
+
+    impl TestGym {
+        pub(super) fn new(steps: impl IntoIterator<Item = StepInfo<TestInfo>>) -> Self {
+            Self {
+                steps: steps.into_iter().collect(),
+                device: Device::Cpu,
+                reset_count: 0,
+            }
+        }
+
+        pub(super) fn step(
+            state: f32,
+            reward: f32,
+            done: bool,
+            truncated: bool,
+            sequence: u32,
+        ) -> StepInfo<TestInfo> {
+            StepInfo {
+                state: Tensor::new(state, &Device::Cpu).unwrap(),
+                reward,
+                done,
+                truncated,
+                info: TestInfo { sequence },
+            }
+        }
+    }
+
+    impl Gym<TestInfo> for TestGym {
+        type Error = candle_core::Error;
+        type SpaceError = candle_core::Error;
+
+        fn step(&mut self, _action: Tensor) -> Result<StepInfo<TestInfo>, Self::Error> {
+            Ok(self.steps.pop_front().expect("test step script exhausted"))
+        }
+
+        fn reset(&mut self) -> Result<ResetInfo<TestInfo>, Self::Error> {
+            self.reset_count += 1;
+            Ok(ResetInfo {
+                state: Tensor::new(100.0 * self.reset_count as f32, &self.device)?,
+                info: TestInfo { sequence: 0 },
+            })
+        }
+
+        fn observation_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {
+            Box::new(BoxSpace::new(
+                Tensor::new(-10_000.0f32, &self.device).unwrap(),
+                Tensor::new(10_000.0f32, &self.device).unwrap(),
+            ))
+        }
+
+        fn action_space(&self) -> Box<dyn Space<Error = Self::SpaceError>> {
+            Box::new(Discrete::new(4))
+        }
+    }
+
+    pub(super) fn action() -> Tensor {
+        Tensor::new(0u32, &Device::Cpu).unwrap()
+    }
+
+    pub(super) fn scalar(tensor: &Tensor) -> f32 {
+        tensor.to_scalar::<f32>().unwrap()
+    }
+}

--- a/src/wrappers/observation.rs
+++ b/src/wrappers/observation.rs
@@ -1,0 +1,206 @@
+//! Wrappers that transform observations.
+
+use std::collections::VecDeque;
+
+use candle_core::Tensor;
+
+use crate::gym::{Gym, ResetInfo, StepInfo};
+
+#[derive(Debug)]
+pub enum FrameStackGymError<E> {
+    GymError(E),
+    CandleError(candle_core::Error),
+}
+
+/// Stacks the most recent observations along a leading frame dimension.
+pub struct FrameStackGym<G> {
+    gym: G,
+    stack_size: usize,
+    frames: VecDeque<Tensor>,
+}
+
+impl<G> FrameStackGym<G> {
+    pub fn new(gym: G, stack_size: usize) -> Self {
+        assert!(stack_size > 0, "stack_size must be at least 1");
+        Self {
+            gym,
+            stack_size,
+            frames: VecDeque::new(),
+        }
+    }
+}
+
+impl<G, I> Gym<I> for FrameStackGym<G>
+where
+    G: Gym<I>,
+{
+    type Error = FrameStackGymError<<G as Gym<I>>::Error>;
+    type SpaceError = <G as Gym<I>>::SpaceError;
+
+    fn reset(&mut self) -> Result<ResetInfo<I>, Self::Error> {
+        let mut reset = self.gym.reset().map_err(FrameStackGymError::GymError)?;
+        self.frames = std::iter::repeat_with(|| reset.state.clone())
+            .take(self.stack_size)
+            .collect();
+        let frames = self.frames.iter().cloned().collect::<Vec<_>>();
+        reset.state = Tensor::stack(&frames, 0).map_err(FrameStackGymError::CandleError)?;
+        Ok(reset)
+    }
+
+    fn step(&mut self, action: Tensor) -> Result<StepInfo<I>, Self::Error> {
+        let mut info = self
+            .gym
+            .step(action)
+            .map_err(FrameStackGymError::GymError)?;
+        if self.frames.len() >= self.stack_size {
+            self.frames.pop_front();
+        }
+        self.frames.push_back(info.state.clone());
+        let frames = self.frames.iter().cloned().collect::<Vec<_>>();
+        info.state = Tensor::stack(&frames, 0).map_err(FrameStackGymError::CandleError)?;
+        Ok(info)
+    }
+
+    fn action_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.action_space()
+    }
+
+    fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.observation_space()
+    }
+}
+
+#[derive(Debug)]
+pub enum MaxAndSkipGymError<E> {
+    GymError(E),
+    CandleError(candle_core::Error),
+}
+
+/// Repeats each action, sums its rewards, and max-pools the final two observations.
+pub struct MaxAndSkipGym<G> {
+    gym: G,
+    skip: usize,
+}
+
+impl<G> MaxAndSkipGym<G> {
+    pub fn new(gym: G, skip: usize) -> Self {
+        assert!(skip > 0, "skip must be at least 1");
+        Self { gym, skip }
+    }
+}
+
+impl<G, I> Gym<I> for MaxAndSkipGym<G>
+where
+    G: Gym<I>,
+{
+    type Error = MaxAndSkipGymError<<G as Gym<I>>::Error>;
+    type SpaceError = <G as Gym<I>>::SpaceError;
+
+    fn reset(&mut self) -> Result<ResetInfo<I>, Self::Error> {
+        self.gym.reset().map_err(MaxAndSkipGymError::GymError)
+    }
+
+    fn step(&mut self, action: Tensor) -> Result<StepInfo<I>, Self::Error> {
+        let mut total_reward = 0.0;
+        let mut last_observation = None;
+        let mut second_last_observation = None;
+        let mut final_step = None;
+
+        for _ in 0..self.skip {
+            let step = self
+                .gym
+                .step(action.clone())
+                .map_err(MaxAndSkipGymError::GymError)?;
+            total_reward += step.reward;
+            second_last_observation = last_observation;
+            last_observation = Some(step.state.clone());
+            let finished = step.done || step.truncated;
+            final_step = Some(step);
+            if finished {
+                break;
+            }
+        }
+
+        let mut step = final_step.expect("skip is validated to be at least one");
+        step.state = match second_last_observation {
+            Some(second_last) => Tensor::maximum(
+                last_observation
+                    .as_ref()
+                    .expect("at least one step was taken"),
+                &second_last,
+            )
+            .map_err(MaxAndSkipGymError::CandleError)?,
+            None => last_observation.expect("at least one step was taken"),
+        };
+        step.reward = total_reward;
+        Ok(step)
+    }
+
+    fn action_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.action_space()
+    }
+
+    fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.observation_space()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        gym::Gym,
+        wrappers::test_support::{TestGym, action, scalar},
+    };
+
+    use super::{FrameStackGym, MaxAndSkipGym};
+
+    #[test]
+    fn frame_stack_duplicates_reset_observation_and_rolls_on_step() {
+        let gym = TestGym::new([TestGym::step(2.0, 0.0, false, false, 1)]);
+        let mut wrapper = FrameStackGym::new(gym, 4);
+
+        let reset = wrapper.reset().unwrap();
+        let step = wrapper.step(action()).unwrap();
+
+        assert_eq!(reset.state.to_vec1::<f32>().unwrap(), vec![100.0; 4]);
+        assert_eq!(
+            step.state.to_vec1::<f32>().unwrap(),
+            vec![100.0, 100.0, 100.0, 2.0]
+        );
+        assert_eq!(step.info.sequence, 1);
+    }
+
+    #[test]
+    fn max_and_skip_pools_final_observations_and_preserves_final_metadata() {
+        let gym = TestGym::new([
+            TestGym::step(1.0, 0.25, false, false, 1),
+            TestGym::step(5.0, 0.25, false, false, 2),
+            TestGym::step(3.0, 0.25, false, false, 3),
+            TestGym::step(2.0, 0.25, false, false, 4),
+        ]);
+        let mut wrapper = MaxAndSkipGym::new(gym, 4);
+
+        let step = wrapper.step(action()).unwrap();
+
+        assert_eq!(scalar(&step.state), 3.0);
+        assert_eq!(step.reward, 1.0);
+        assert_eq!(step.info.sequence, 4);
+    }
+
+    #[test]
+    fn max_and_skip_stops_on_truncation() {
+        let gym = TestGym::new([
+            TestGym::step(1.0, 0.25, false, false, 1),
+            TestGym::step(2.0, 0.25, false, true, 2),
+            TestGym::step(3.0, 0.25, false, false, 3),
+        ]);
+        let mut wrapper = MaxAndSkipGym::new(gym, 4);
+
+        let step = wrapper.step(action()).unwrap();
+
+        assert_eq!(scalar(&step.state), 2.0);
+        assert_eq!(step.reward, 0.5);
+        assert!(step.truncated);
+        assert_eq!(step.info.sequence, 2);
+    }
+}

--- a/src/wrappers/reward.rs
+++ b/src/wrappers/reward.rs
@@ -1,0 +1,71 @@
+//! Wrappers that transform rewards.
+
+use candle_core::Tensor;
+
+use crate::gym::{Gym, ResetInfo, StepInfo};
+
+#[derive(Debug)]
+pub enum ClipRewardGymError<E> {
+    GymError(E),
+}
+
+/// Maps each nonzero reward to its sign.
+pub struct ClipRewardGym<G> {
+    gym: G,
+}
+
+impl<G> ClipRewardGym<G> {
+    pub fn new(gym: G) -> Self {
+        Self { gym }
+    }
+}
+
+impl<G, I> Gym<I> for ClipRewardGym<G>
+where
+    G: Gym<I>,
+{
+    type Error = ClipRewardGymError<<G as Gym<I>>::Error>;
+    type SpaceError = <G as Gym<I>>::SpaceError;
+
+    fn reset(&mut self) -> Result<ResetInfo<I>, Self::Error> {
+        self.gym.reset().map_err(ClipRewardGymError::GymError)
+    }
+
+    fn step(&mut self, action: Tensor) -> Result<StepInfo<I>, Self::Error> {
+        let mut info = self
+            .gym
+            .step(action)
+            .map_err(ClipRewardGymError::GymError)?;
+        info.reward = info.reward.signum();
+        Ok(info)
+    }
+
+    fn action_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.action_space()
+    }
+
+    fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.observation_space()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        gym::Gym,
+        wrappers::test_support::{TestGym, action},
+    };
+
+    use super::ClipRewardGym;
+
+    #[test]
+    fn maps_reward_to_its_sign_and_preserves_metadata() {
+        let gym = TestGym::new([TestGym::step(1.0, 2.5, false, false, 7)]);
+        let mut wrapper = ClipRewardGym::new(gym);
+
+        let step = wrapper.step(action()).unwrap();
+
+        assert_eq!(step.reward, 1.0);
+        assert_eq!(step.info.sequence, 7);
+    }
+}

--- a/src/wrappers/time_limit.rs
+++ b/src/wrappers/time_limit.rs
@@ -1,0 +1,86 @@
+//! Episode time-limit wrapper.
+
+use candle_core::Tensor;
+
+use crate::gym::{Gym, ResetInfo, StepInfo};
+
+/// Truncates an episode after a fixed number of environment steps.
+pub struct TimeLimitGym<G> {
+    gym: G,
+    max_episode_steps: u32,
+    elapsed_steps: u32,
+}
+
+impl<G> TimeLimitGym<G> {
+    pub fn new(gym: G, max_episode_steps: u32) -> Self {
+        assert!(
+            max_episode_steps > 0,
+            "max_episode_steps must be at least 1"
+        );
+        Self {
+            gym,
+            max_episode_steps,
+            elapsed_steps: 0,
+        }
+    }
+}
+
+impl<G, I> Gym<I> for TimeLimitGym<G>
+where
+    G: Gym<I>,
+{
+    type Error = <G as Gym<I>>::Error;
+    type SpaceError = <G as Gym<I>>::SpaceError;
+
+    fn reset(&mut self) -> Result<ResetInfo<I>, Self::Error> {
+        self.elapsed_steps = 0;
+        self.gym.reset()
+    }
+
+    fn step(&mut self, action: Tensor) -> Result<StepInfo<I>, Self::Error> {
+        let mut info = self.gym.step(action)?;
+        self.elapsed_steps += 1;
+        if self.elapsed_steps >= self.max_episode_steps && !info.done {
+            info.truncated = true;
+        }
+        Ok(info)
+    }
+
+    fn action_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.action_space()
+    }
+
+    fn observation_space(&self) -> Box<dyn crate::spaces::Space<Error = Self::SpaceError>> {
+        self.gym.observation_space()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        gym::Gym,
+        wrappers::test_support::{TestGym, action},
+    };
+
+    use super::TimeLimitGym;
+
+    #[test]
+    fn truncates_at_limit_and_resets_elapsed_steps() {
+        let gym = TestGym::new([
+            TestGym::step(1.0, 0.0, false, false, 1),
+            TestGym::step(2.0, 0.0, false, false, 2),
+            TestGym::step(3.0, 0.0, false, false, 3),
+        ]);
+        let mut wrapper = TimeLimitGym::new(gym, 2);
+
+        wrapper.reset().unwrap();
+        let first = wrapper.step(action()).unwrap();
+        let second = wrapper.step(action()).unwrap();
+        wrapper.reset().unwrap();
+        let after_reset = wrapper.step(action()).unwrap();
+
+        assert!(!first.truncated);
+        assert!(second.truncated);
+        assert!(!after_reset.truncated);
+    }
+}

--- a/tests/documentation_examples.rs
+++ b/tests/documentation_examples.rs
@@ -337,9 +337,12 @@ impl Gym for CounterEnv {
     type Error = candle_core::Error;
     type SpaceError = candle_core::Error;
 
-    fn reset(&mut self) -> Result<Tensor, Self::Error> {
+    fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
         self.state = 0;
-        self.observation()
+        Ok(ResetInfo {
+            state: self.observation()?,
+            info: (),
+        })
     }
 
     fn step(&mut self, action: Tensor) -> Result<StepInfo, Self::Error> {
@@ -355,6 +358,7 @@ impl Gym for CounterEnv {
             reward: 1.0,
             done,
             truncated: false,
+            info: (),
         })
     }
 

--- a/tests/test_cartpole.rs
+++ b/tests/test_cartpole.rs
@@ -62,7 +62,7 @@ impl Gym for DebugCartpoleV1 {
         self.env.step(action)
     }
 
-    fn reset(&mut self) -> Result<candle_core::Tensor, Self::Error> {
+    fn reset(&mut self) -> Result<ResetInfo, Self::Error> {
         self.episodes_since_print += 1;
         if self.episodes_since_print >= 10 {
             println!(


### PR DESCRIPTION
Adds a generic `Info` to the `Gym` trait. This allows for info to be passed around with gyms, which is sometimes necessary. For example, in Atari we previously used a `GetLives` trait that every wrapper implemented and required in its wrapped gym. Now info can just include lives and the `EpisodicLifeWrapper` can require the type of Info to be `AtariInfo`.